### PR TITLE
feat: add gh-chat-dataset CLI to convert GitHub repos to Qwen chat JSONL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Outputs
+out/
+output/
+*.jsonl
+stats.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# gh-chat-dataset
+
+Convert GitHub repositories to Qwen chat JSONL datasets for MLX fine-tuning.
+
+## Features
+
+- **Python AST extraction**: Functions, classes, module docstrings
+- **JavaScript/TypeScript**: JSDoc comments and function bodies  
+- **Markdown sections**: All `.md` files split by headings
+- **Chat/messages format**: Qwen-compatible JSONL output
+- **Post-processing**: Length filtering, deduplication
+- **Train/valid split**: Configurable ratio (default 90/10)
+
+## Installation
+
+```bash
+pip install -e .[dev]
+```
+
+## Usage
+
+Convert a public GitHub repo:
+
+```bash
+gh-chat-dataset --repo https://github.com/owner/repo.git --out ./output --max-tokens 2048
+```
+
+Options:
+- `--repo`: GitHub repository URL
+- `--out`: Output directory  
+- `--max-tokens`: Maximum tokens per sample (approximate)
+- `--allow-llm`: Enable LLM-assisted labeling (stubbed)
+- `--split-ratio`: Train/validation split ratio (default 0.9)
+
+## Output
+
+- `dataset.train.jsonl`: Training samples
+- `dataset.valid.jsonl`: Validation samples  
+- `stats.json`: Dataset statistics
+
+### Sample Format
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "You are a helpful Python documentation assistant."},
+    {"role": "user", "content": "Write a docstring for this function:\\n\\ndef hello(name): ..."},
+    {"role": "assistant", "content": "Say hello to someone."}
+  ],
+  "meta": {
+    "file_path": "src/utils.py",
+    "task": "python_docstring",
+    "kind": "FunctionDef"
+  }
+}
+```
+
+## Development
+
+```bash
+# Install with dev dependencies
+pip install -e .[dev]
+
+# Run tests
+pytest
+
+# Lint
+ruff check .
+```

--- a/README.md
+++ b/README.md
@@ -1,69 +1,274 @@
-# gh-chat-dataset
+# 🤖 gh-chat-dataset: Turn Any GitHub Repo into AI Training Data
 
-Convert GitHub repositories to Qwen chat JSONL datasets for MLX fine-tuning.
+**One-click tool to convert GitHub repositories into high-quality chat datasets for fine-tuning language models like Qwen with MLX.**
 
-## Features
+> 💡 **Perfect for**: Training coding assistants, documentation bots, or domain-specific AI models from real codebases.
 
-- **Python AST extraction**: Functions, classes, module docstrings
-- **JavaScript/TypeScript**: JSDoc comments and function bodies  
-- **Markdown sections**: All `.md` files split by headings
-- **Chat/messages format**: Qwen-compatible JSONL output
-- **Post-processing**: Length filtering, deduplication
-- **Train/valid split**: Configurable ratio (default 90/10)
+## 🎯 What Does This Do?
 
-## Installation
+This tool automatically extracts meaningful code-documentation pairs from GitHub repositories and formats them as conversation data that AI models can learn from. 
 
+**Think of it as**: Taking a repository full of Python functions with docstrings, JavaScript with JSDoc comments, and README files, then converting them into "teacher-student" conversations for AI training.
+
+### 🧠 The Magic Behind It
+
+- **Python Functions** → "Write a docstring for this function" conversations
+- **JavaScript/TypeScript** → "Add JSDoc comments to this code" examples  
+- **Markdown Documentation** → "Explain this section" Q&A pairs
+- **Smart Processing** → Removes duplicates, filters by length, splits for training
+
+## 🚀 Quick Start (3 Minutes)
+
+### Step 1: Install
 ```bash
+# Clone this repository
+git clone https://github.com/ArjunDivecha/Repo2Dataset.git
+cd Repo2Dataset
+
+# Install the tool
 pip install -e .[dev]
 ```
 
-## Usage
-
-Convert a public GitHub repo:
-
+### Step 2: Convert a Repository
 ```bash
-gh-chat-dataset --repo https://github.com/owner/repo.git --out ./output --max-tokens 2048
+# Example: Convert the popular 'requests' library into training data
+gh-chat-dataset --repo https://github.com/psf/requests.git --out ./requests_dataset
+
+# Or try a smaller example first
+gh-chat-dataset --repo https://github.com/pallets/itsdangerous.git --out ./test_dataset
 ```
 
-Options:
-- `--repo`: GitHub repository URL
-- `--out`: Output directory  
-- `--max-tokens`: Maximum tokens per sample (approximate)
-- `--allow-llm`: Enable LLM-assisted labeling (stubbed)
-- `--split-ratio`: Train/validation split ratio (default 0.9)
+### Step 3: Check Your Results
+```bash
+ls test_dataset/
+# You'll see:
+# dataset.train.jsonl  <- 90% of samples for training
+# dataset.valid.jsonl  <- 10% of samples for validation  
+# stats.json          <- Summary of what was extracted
+```
 
-## Output
+## 📊 Real Example Output
 
-- `dataset.train.jsonl`: Training samples
-- `dataset.valid.jsonl`: Validation samples  
-- `stats.json`: Dataset statistics
+Let's say you run it on a Python repository. Here's what one training sample looks like:
 
-### Sample Format
+**Input** (what the AI sees):
+```
+Write a clear, concise docstring for this function:
+
+def validate_email(email):
+    pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}
+    return re.match(pattern, email) is not None
+```
+
+**Expected Output** (what the AI should respond):
+```
+Validate if an email address has a proper format.
+
+Args:
+    email (str): The email address to validate.
+
+Returns:
+    bool: True if email format is valid, False otherwise.
+```
+
+This creates training data that teaches AI models to write good documentation!
+
+## ⚙️ All Command Options Explained
+
+```bash
+gh-chat-dataset [OPTIONS]
+```
+
+### Required Options
+- `--repo URL` - The GitHub repository to convert (must be public or you need access)
+- `--out DIRECTORY` - Where to save the dataset files
+
+### Optional Fine-Tuning
+- `--max-tokens 2048` - Skip samples longer than this (prevents memory issues)
+- `--split-ratio 0.9` - How much data goes to training vs validation (0.9 = 90% train, 10% validation)
+- `--allow-llm` - *(Experimental)* Use AI to generate labels where missing
+
+### Real Examples
+```bash
+# Basic usage
+gh-chat-dataset --repo https://github.com/user/repo.git --out ./my_dataset
+
+# For larger models (more context)
+gh-chat-dataset --repo https://github.com/user/repo.git --out ./my_dataset --max-tokens 4096
+
+# More data for validation
+gh-chat-dataset --repo https://github.com/user/repo.git --out ./my_dataset --split-ratio 0.8
+```
+
+## 📁 What Gets Extracted?
+
+### From Python Files (.py)
+- ✅ Functions with docstrings → "Write docstring" examples
+- ✅ Classes with docstrings → "Document this class" examples  
+- ✅ Module docstrings → "Summarize this module" examples
+
+### From JavaScript/TypeScript (.js, .jsx, .ts, .tsx)
+- ✅ Functions with JSDoc comments → "Add JSDoc" examples
+- ✅ Complex function signatures → Documentation examples
+
+### From Markdown Files (.md)
+- ✅ README sections → "Explain this concept" Q&A
+- ✅ Documentation pages → Knowledge Q&A pairs
+- ✅ API docs → Usage explanation examples
+
+### What Gets Filtered Out
+- ❌ Files without documentation (can't create good training pairs)
+- ❌ Very short or very long samples (poor quality for training)
+- ❌ Duplicate content (prevents overfitting)
+- ❌ Generated files (node_modules, build outputs, etc.)
+
+## 📈 Understanding Your Output
+
+After running the tool, check `stats.json`:
 
 ```json
 {
-  "messages": [
-    {"role": "system", "content": "You are a helpful Python documentation assistant."},
-    {"role": "user", "content": "Write a docstring for this function:\\n\\ndef hello(name): ..."},
-    {"role": "assistant", "content": "Say hello to someone."}
-  ],
-  "meta": {
-    "file_path": "src/utils.py",
-    "task": "python_docstring",
-    "kind": "FunctionDef"
+  "sha": "abc123...",           // Exact version of repo used
+  "counts": {
+    "total": 156,               // Total samples created
+    "train": 140,               // Training samples (90%)
+    "valid": 16                 // Validation samples (10%)
   }
 }
 ```
 
-## Development
+**Good numbers to see:**
+- 50+ total samples for small projects
+- 500+ total samples for substantial codebases
+- 1000+ total samples for large, well-documented projects
+
+## 🎯 Perfect Repositories to Try
+
+### Great for Beginners
+- `pallets/itsdangerous` - Small, well-documented Python library
+- `sindresorhus/is` - Simple JavaScript utilities with good docs
+- `getsentry/sentry-python` - Medium-sized Python project
+
+### For Larger Datasets  
+- `psf/requests` - Popular Python HTTP library
+- `microsoft/TypeScript` - Large TypeScript codebase
+- `django/django` - Web framework with extensive docs
+
+### Best Results Come From
+- ✅ Well-documented codebases
+- ✅ Projects with consistent docstring/JSDoc style
+- ✅ Repositories with good README files
+- ✅ Active projects (recent commits)
+
+## 🛠 Using Your Dataset with MLX
+
+Once you have your dataset, here's how to use it for fine-tuning:
+
+```python
+# Load your dataset
+import json
+
+def load_dataset(path):
+    with open(path, 'r') as f:
+        return [json.loads(line) for line in f]
+
+train_data = load_dataset('your_dataset/dataset.train.jsonl')
+valid_data = load_dataset('your_dataset/dataset.valid.jsonl')
+
+# Each sample has this format:
+sample = train_data[0]
+print(sample['messages'])  # The conversation
+print(sample['meta'])      # Metadata about source
+```
+
+**Pro Tip**: The `messages` format is compatible with most modern fine-tuning frameworks including MLX, transformers, and OpenAI's fine-tuning API.
+
+## 🔧 Troubleshooting
+
+### "No samples extracted"
+- ✅ Make sure the repo has documented code (docstrings, JSDoc, README)
+- ✅ Try a well-known repo first (like `pallets/itsdangerous`)
+- ✅ Check if the repo is public or you have access
+
+### "Permission denied" errors
+- ✅ Make sure you can access the repository
+- ✅ For private repos, ensure your Git credentials are set up
+- ✅ Try with a public repository first
+
+### "Out of memory" errors  
+- ✅ Use `--max-tokens 1024` for smaller samples
+- ✅ Try processing smaller repositories first
+- ✅ Make sure you have sufficient disk space
+
+### Dataset is too small
+- ✅ Try repositories with more documentation
+- ✅ Look for projects with consistent docstring styles
+- ✅ Consider enabling `--allow-llm` for more samples (experimental)
+
+## 🚀 Advanced Usage
+
+### Batch Processing Multiple Repos
+```bash
+# Create a script to process multiple repositories
+repos=(
+  "https://github.com/user/repo1.git"
+  "https://github.com/user/repo2.git" 
+  "https://github.com/user/repo3.git"
+)
+
+for repo in "${repos[@]}"; do
+  name=$(basename "$repo" .git)
+  gh-chat-dataset --repo "$repo" --out "./datasets/$name"
+done
+```
+
+### Combining Datasets
+```bash
+# Merge multiple datasets
+cat dataset1/dataset.train.jsonl dataset2/dataset.train.jsonl > combined_train.jsonl
+cat dataset1/dataset.valid.jsonl dataset2/dataset.valid.jsonl > combined_valid.jsonl
+```
+
+## 👨‍💻 Contributing & Development
+
+Want to improve the tool? Here's how to set up for development:
 
 ```bash
-# Install with dev dependencies
+# Clone and setup
+git clone https://github.com/ArjunDivecha/Repo2Dataset.git
+cd Repo2Dataset
+
+# Install in development mode
 pip install -e .[dev]
 
-# Run tests
+# Run tests to make sure everything works
 pytest
 
-# Lint
+# Check code style
 ruff check .
+
+# Make your changes, then test
+python -m pytest
 ```
+
+### Adding New File Types
+The tool is designed to be extensible. To add support for new languages:
+
+1. Create a new extractor in `gh_chat_dataset/extract_xxx.py`
+2. Add a builder function in `gh_chat_dataset/builders.py`
+3. Update the file discovery patterns in `gh_chat_dataset/discover.py`
+4. Add tests in `tests/`
+
+## 📄 License
+
+MIT License - feel free to use this for any project!
+
+## 🙋‍♀️ Questions?
+
+- 📖 Check the troubleshooting section above
+- 🐛 Found a bug? [Open an issue](https://github.com/ArjunDivecha/Repo2Dataset/issues)
+- 💡 Have an idea? [Start a discussion](https://github.com/ArjunDivecha/Repo2Dataset/discussions)
+
+---
+
+**Happy Training! 🤖✨**

--- a/gh_chat_dataset/__init__.py
+++ b/gh_chat_dataset/__init__.py
@@ -1,0 +1,3 @@
+"""GitHub to Chat Dataset converter for MLX fine-tuning."""
+
+__version__ = "0.1.0"

--- a/gh_chat_dataset/builders.py
+++ b/gh_chat_dataset/builders.py
@@ -1,0 +1,136 @@
+"""Chat message builders for different content types."""
+
+from pathlib import Path
+from typing import Dict, List
+
+from . import extract_js, extract_md, extract_py
+
+
+def build_samples_from_file(
+    file_path: Path, repo_path: Path, allow_llm: bool = False
+) -> List[Dict]:
+    """Build chat samples from a single file."""
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, PermissionError):
+        return []
+
+    rel_path = file_path.relative_to(repo_path)
+    samples = []
+
+    if file_path.suffix == ".py":
+        items = extract_py.extract_python_items(rel_path, content)
+        for item in items:
+            sample = build_python_docstring_sample(item)
+            if sample:
+                samples.append(sample)
+
+    elif file_path.suffix in {".js", ".jsx", ".ts", ".tsx"}:
+        items = extract_js.extract_js_items(rel_path, content)
+        for item in items:
+            sample = build_js_jsdoc_sample(item)
+            if sample:
+                samples.append(sample)
+
+    elif file_path.suffix == ".md":
+        sections = extract_md.extract_markdown_sections(rel_path, content)
+        for section in sections:
+            sample = build_markdown_qa_sample(section)
+            if sample:
+                samples.append(sample)
+
+    # TODO: LLM-assisted labeling when allow_llm=True
+    if allow_llm:
+        pass  # Stub for model-assisted sample generation
+
+    return samples
+
+
+def build_python_docstring_sample(item: Dict) -> Dict:
+    """Build chat sample for Python docstring task."""
+    if not item.get("docstring") or not item.get("code"):
+        return None
+
+    return {
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful Python code documentation assistant.",
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Write a clear, concise docstring for this "
+                    f"{item['kind'].lower()}:\n\n{item['code']}"
+                ),
+            },
+            {"role": "assistant", "content": item["docstring"]},
+        ],
+        "meta": {
+            "file_path": item["file_path"],
+            "kind": item["kind"],
+            "name": item.get("name"),
+            "task": "python_docstring",
+        },
+    }
+
+
+def build_js_jsdoc_sample(item: Dict) -> Dict:
+    """Build chat sample for JSDoc task."""
+    if not item.get("jsdoc") or not item.get("code"):
+        return None
+
+    return {
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful JavaScript/TypeScript documentation "
+                    "assistant."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Write a JSDoc comment for this function:\n\n{item['code']}"
+                ),
+            },
+            {"role": "assistant", "content": item["jsdoc"]},
+        ],
+        "meta": {
+            "file_path": item["file_path"],
+            "kind": item["kind"],
+            "name": item.get("name"),
+            "task": "js_jsdoc",
+        },
+    }
+
+
+def build_markdown_qa_sample(section: Dict) -> Dict:
+    """Build chat sample for Markdown Q&A task."""
+    if not section.get("title") or not section.get("content"):
+        return None
+
+    # Skip very short sections
+    if len(section["content"]) < 50:
+        return None
+
+    return {
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful documentation assistant.",
+            },
+            {
+                "role": "user",
+                "content": f"Explain the section titled '{section['title']}'.",
+            },
+            {"role": "assistant", "content": section["content"]},
+        ],
+        "meta": {
+            "file_path": section["file_path"],
+            "kind": section["kind"],
+            "title": section["title"],
+            "task": "markdown_qa",
+        },
+    }

--- a/gh_chat_dataset/cli.py
+++ b/gh_chat_dataset/cli.py
@@ -1,0 +1,95 @@
+"""CLI interface for gh-chat-dataset."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import click
+from git import Repo
+
+from . import builders, discover, postprocess
+
+
+@click.command()
+@click.option(
+    "--repo", required=True, help="GitHub repo URL (https://github.com/owner/repo.git)"
+)
+@click.option("--out", required=True, help="Output directory")
+@click.option(
+    "--max-tokens", default=2048, help="Max tokens per sample (approx)", type=int
+)
+@click.option(
+    "--allow-llm", is_flag=True, help="Enable LLM-assisted labeling (stubbed)"
+)
+@click.option("--split-ratio", default=0.9, help="Train/valid split ratio", type=float)
+def main(repo, out, max_tokens, allow_llm, split_ratio):
+    """Convert GitHub repo to Qwen chat JSONL for MLX fine-tuning."""
+    out_path = Path(out)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Clone repo
+        click.echo(f"Cloning {repo}...")
+        repo_obj = Repo.clone_from(repo, tmp_dir, depth=1)
+        sha = repo_obj.head.commit.hexsha
+        click.echo(f"SHA: {sha}")
+
+        # Discover files
+        repo_path = Path(tmp_dir)
+        files = discover.find_files(repo_path)
+        click.echo(f"Found {len(files)} files")
+
+        # Extract and build samples
+        samples = []
+        for file_path in files:
+            file_samples = builders.build_samples_from_file(
+                file_path, repo_path, allow_llm=allow_llm
+            )
+            samples.extend(file_samples)
+
+        click.echo(f"Extracted {len(samples)} raw samples")
+
+        # Post-process
+        samples = postprocess.filter_samples(samples, max_tokens=max_tokens)
+        click.echo(f"After filtering: {len(samples)} samples")
+
+        # Split train/valid
+        import random
+
+        random.shuffle(samples)
+        split_idx = int(len(samples) * split_ratio)
+        train_samples = samples[:split_idx]
+        valid_samples = samples[split_idx:]
+
+        # Export
+        train_path = out_path / "dataset.train.jsonl"
+        valid_path = out_path / "dataset.valid.jsonl"
+        stats_path = out_path / "stats.json"
+
+        _write_jsonl(train_path, train_samples)
+        _write_jsonl(valid_path, valid_samples)
+
+        stats = {
+            "sha": sha,
+            "counts": {
+                "total": len(samples),
+                "train": len(train_samples),
+                "valid": len(valid_samples),
+            },
+        }
+
+        with open(stats_path, "w") as f:
+            json.dump(stats, f, indent=2)
+
+        click.echo(json.dumps(stats))
+
+
+def _write_jsonl(path, samples):
+    """Write samples to JSONL file."""
+    with open(path, "w", encoding="utf-8") as f:
+        for sample in samples:
+            f.write(json.dumps(sample, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/gh_chat_dataset/discover.py
+++ b/gh_chat_dataset/discover.py
@@ -1,0 +1,32 @@
+"""File discovery utilities."""
+
+from pathlib import Path
+from typing import List
+
+
+def find_files(repo_path: Path) -> List[Path]:
+    """Find Python, JS/TS, and Markdown files in a repo."""
+    patterns = ["**/*.py", "**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.md"]
+    exclude_dirs = {
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".pytest_cache",
+        "build",
+        "dist",
+        ".venv",
+        "venv",
+        ".mypy_cache",
+        "coverage",
+    }
+
+    files = []
+    for pattern in patterns:
+        for file_path in repo_path.glob(pattern):
+            # Skip if any parent dir is in exclude list
+            if any(part in exclude_dirs for part in file_path.parts):
+                continue
+            if file_path.is_file():
+                files.append(file_path)
+
+    return sorted(files)

--- a/gh_chat_dataset/extract_js.py
+++ b/gh_chat_dataset/extract_js.py
@@ -1,0 +1,61 @@
+"""JavaScript/TypeScript JSDoc extraction utilities."""
+
+import re
+from pathlib import Path
+from typing import Dict, List
+
+
+def extract_js_items(file_path: Path, content: str) -> List[Dict]:
+    """Extract JSDoc + function pairs from JS/TS code."""
+    items = []
+
+    # Pattern for JSDoc comment followed by function
+    jsdoc_func_pattern = re.compile(
+        r"/\\*\\*(.*?)\\*/\\s*"  # JSDoc comment
+        r"(?:export\\s+)?"  # Optional export
+        r"(?:async\\s+)?"   # Optional async
+        r"(?:function\\s+([a-zA-Z0-9_$]+)|"  # Named function
+        r"(?:const|let|var)\\s+([a-zA-Z0-9_$]+)\\s*=\\s*"  # Arrow function
+        r"(?:async\\s+)?\\([^)]*\\)\\s*=>)",
+        re.DOTALL | re.MULTILINE
+    )
+
+    for match in jsdoc_func_pattern.finditer(content):
+        jsdoc = match.group(1).strip()
+        func_name = match.group(2) or match.group(3) or "anonymous"
+
+        # Extract function body (naive approach)
+        jsdoc_end = match.end()
+
+        # Find the function definition after JSDoc
+        func_match = re.search(
+            r"(?:export\\s+)?(?:async\\s+)?(?:function\\s+\\w+|"
+            r"(?:const|let|var)\\s+\\w+\\s*=\\s*(?:async\\s+)?\\([^)]*\\)\\s*=>)",
+            content[jsdoc_end:]
+        )
+
+        if func_match:
+            # Try to find the complete function (simplified)
+            brace_pos = content.find("{", jsdoc_end + func_match.start())
+            if brace_pos != -1:
+                # Count braces to find function end
+                depth = 0
+                i = brace_pos
+                while i < len(content):
+                    if content[i] == "{":
+                        depth += 1
+                    elif content[i] == "}":
+                        depth -= 1
+                        if depth == 0:
+                            func_code = content[jsdoc_end + func_match.start():i + 1]
+                            items.append({
+                                "kind": "Function",
+                                "name": func_name,
+                                "jsdoc": jsdoc,
+                                "code": func_code.strip(),
+                                "file_path": str(file_path),
+                            })
+                            break
+                    i += 1
+
+    return items

--- a/gh_chat_dataset/extract_md.py
+++ b/gh_chat_dataset/extract_md.py
@@ -1,0 +1,51 @@
+"""Markdown section extraction utilities."""
+
+import re
+from pathlib import Path
+from typing import Dict, List
+
+
+def extract_markdown_sections(file_path: Path, content: str) -> List[Dict]:
+    """Extract sections from Markdown files based on headings."""
+    sections = []
+    current_section = {"title": "", "content": []}
+
+    for line in content.splitlines():
+        # Check if line is a heading (# ## ### etc.)
+        heading_match = re.match(r"^(#{1,6})\s+(.+)$", line)
+
+        if heading_match:
+            # Save previous section if it has content
+            if current_section["content"]:
+                content_text = "\n".join(current_section["content"]).strip()
+                if content_text:
+                    sections.append({
+                        "kind": "Section",
+                        "title": current_section["title"],
+                        "content": content_text,
+                        "file_path": str(file_path),
+                        "level": len(heading_match.group(1)),
+                    })
+
+            # Start new section
+            current_section = {
+                "title": heading_match.group(2).strip(),
+                "content": []
+            }
+        else:
+            # Add line to current section
+            current_section["content"].append(line)
+
+    # Don't forget the last section
+    if current_section["content"]:
+        content_text = "\n".join(current_section["content"]).strip()
+        if content_text:
+            sections.append({
+                "kind": "Section",
+                "title": current_section["title"],
+                "content": content_text,
+                "file_path": str(file_path),
+                "level": 1,  # Default level for last section
+            })
+
+    return sections

--- a/gh_chat_dataset/extract_py.py
+++ b/gh_chat_dataset/extract_py.py
@@ -1,0 +1,49 @@
+"""Python AST extraction utilities."""
+
+import ast
+from pathlib import Path
+from typing import Dict, List
+
+
+def extract_python_items(file_path: Path, content: str) -> List[Dict]:
+    """Extract functions, classes, and module docstrings from Python code."""
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return []
+
+    lines = content.splitlines()
+    items = []
+
+    def get_source_segment(node):
+        """Get source code for an AST node."""
+        start = node.lineno - 1
+        end = getattr(node, "end_lineno", start + 1)
+        return "\n".join(lines[start:end])
+
+    # Module docstring
+    module_doc = ast.get_docstring(tree)
+    if module_doc and module_doc.strip():
+        items.append({
+            "kind": "Module",
+            "name": file_path.name,
+            "docstring": module_doc.strip(),
+            "code": content,
+            "file_path": str(file_path),
+        })
+
+    # Functions and classes
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            docstring = ast.get_docstring(node)
+            if docstring and docstring.strip():
+                code = get_source_segment(node)
+                items.append({
+                    "kind": type(node).__name__,
+                    "name": getattr(node, "name", None),
+                    "docstring": docstring.strip(),
+                    "code": code,
+                    "file_path": str(file_path),
+                })
+
+    return items

--- a/gh_chat_dataset/postprocess.py
+++ b/gh_chat_dataset/postprocess.py
@@ -1,0 +1,41 @@
+"""Post-processing utilities for samples."""
+
+import hashlib
+from typing import Dict, List
+
+
+def filter_samples(samples: List[Dict], max_tokens: int = 2048) -> List[Dict]:
+    """Filter and deduplicate samples."""
+    # Approximate token counting (replace with real tokenizer)
+    def count_tokens(text: str) -> int:
+        return max(1, len(text) // 4)  # Rough approximation
+
+    # Filter by length
+    filtered = []
+    for sample in samples:
+        total_tokens = 0
+        for msg in sample.get("messages", []):
+            total_tokens += count_tokens(msg.get("content", ""))
+
+        if total_tokens <= max_tokens:
+            filtered.append(sample)
+
+    # Deduplicate by message content hash
+    seen = set()
+    deduplicated = []
+
+    for sample in filtered:
+        # Create hash from all message contents
+        content_parts = []
+        for msg in sample.get("messages", []):
+            content_parts.append(f"{msg.get('role', '')}:{msg.get('content', '')}")
+
+        content_hash = hashlib.sha256(
+            "\n".join(content_parts).encode("utf-8")
+        ).hexdigest()
+
+        if content_hash not in seen:
+            seen.add(content_hash)
+            deduplicated.append(sample)
+
+    return deduplicated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "gh-chat-dataset"
+version = "0.1.0"
+description = "Convert GitHub repos to Qwen chat JSONL for MLX fine-tuning"
+authors = [{name = "Arjun Divecha"}]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "click>=8.0.0",
+    "requests>=2.25.0",
+    "gitpython>=3.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.1.0",
+    "pytest>=7.0.0",
+]
+
+[project.scripts]
+gh-chat-dataset = "gh_chat_dataset.cli:main"
+
+[tool.ruff]
+line-length = 88
+target-version = "py38"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "B", "S", "C4", "UP"]
+ignore = ["S101", "S603", "S607"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,79 @@
+"""Tests for extraction modules."""
+
+from pathlib import Path
+
+from gh_chat_dataset import extract_md, extract_py
+
+
+def test_python_extraction():
+    """Test Python AST extraction."""
+    code = '''"""Module docstring."""
+
+def hello(name: str) -> str:
+    """Say hello to someone.
+
+    Args:
+        name: The person's name.
+
+    Returns:
+        A greeting message.
+    """
+    return f"Hello, {name}!"
+
+class Greeter:
+    """A class for greeting people."""
+
+    def greet(self, name: str) -> str:
+        """Greet someone."""
+        return f"Hi, {name}!"
+'''
+
+    items = extract_py.extract_python_items(Path("test.py"), code)
+    assert len(items) >= 3  # module, function, class (may include method)
+
+    # Check module docstring
+    module_item = next(item for item in items if item["kind"] == "Module")
+    assert module_item["docstring"] == "Module docstring."
+
+    # Check function
+    func_item = next(item for item in items if item["name"] == "hello")
+    assert "Say hello to someone." in func_item["docstring"]
+
+
+def test_markdown_extraction():
+    """Test Markdown section extraction."""
+    content = '''# Introduction
+
+This is the intro.
+
+## Getting Started
+
+Here's how to start.
+
+### Installation
+
+Run pip install.
+
+## Advanced Usage
+
+More complex examples.
+'''
+
+    sections = extract_md.extract_markdown_sections(Path("README.md"), content)
+    assert len(sections) >= 3
+
+    # Check first section
+    intro_section = next(s for s in sections if s["title"] == "Introduction")
+    assert "This is the intro." in intro_section["content"]
+
+
+def test_empty_inputs():
+    """Test handling of empty/invalid inputs."""
+    # Empty Python code
+    assert extract_py.extract_python_items(Path("empty.py"), "") == []
+
+    # Invalid Python syntax
+    assert extract_py.extract_python_items(Path("bad.py"), "def broken(") == []
+
+    # Empty Markdown
+    assert extract_md.extract_markdown_sections(Path("empty.md"), "") == []


### PR DESCRIPTION
## Overview

One-shot CLI tool to convert GitHub repositories (Python/JS/TS + Markdown) into Qwen-compatible chat JSONL datasets for MLX fine-tuning.

## Features Implemented

✅ **Python AST extraction**: Functions, classes, module docstrings  
✅ **JavaScript/TypeScript**: JSDoc comments + function bodies
✅ **Markdown sections**: All .md files split by headings for Q&A
✅ **Chat/messages format**: Qwen-compatible JSONL output
✅ **Post-processing**: Length filtering, deduplication  
✅ **Train/valid split**: Configurable ratio (default 90/10)
✅ **CLI interface**: Clean options for repo URL, output, tokens, LLM-assist
✅ **Quality validation**: Ruff linting, pytest tests
✅ **Working demo**: Successfully tested on pallets/itsdangerous (48 samples)

## Quality Evidence

**Linting**: ✅ All checks passed  
**Tests**: ✅ 3/3 passed  
**Demo run**: ✅ 48 samples extracted from itsdangerous repo

## Usage

```bash
pip install -e .[dev]
gh-chat-dataset --repo https://github.com/owner/repo.git --out ./output --max-tokens 2048
```

## Sample Output Format

```json
{
  "messages": [
    {"role": "system", "content": "You are a helpful Python documentation assistant."},
    {"role": "user", "content": "Write a docstring for this function:\n\ndef hello(name): ..."},
    {"role": "assistant", "content": "Say hello to someone."}
  ],
  "meta": {
    "file_path": "src/utils.py",
    "task": "python_docstring",
    "kind": "FunctionDef"
  }
}
```

Ready for MLX fine-tuning workflows!

**Droid-assisted implementation**